### PR TITLE
Prevent including display_description field in course metadata

### DIFF
--- a/cms/djangoapps/models/settings/course_metadata.py
+++ b/cms/djangoapps/models/settings/course_metadata.py
@@ -116,7 +116,8 @@ class CourseMetadata(object):
         """
         result = {}
         for field in descriptor.fields.values():
-            if field.scope != Scope.settings:
+            # temp bug fix: display_description not implemented for course
+            if field.scope != Scope.settings or field.name == 'display_description':
                 continue
             result[field.name] = {
                 'value': field.read_json(descriptor),


### PR DESCRIPTION
- This is temp bug fix for blowing up advanced settings until I figure out where I forced platform to use  display_description in course metadata fields (instead for section and subsection only)