### PR TITLE
KF-518: As a staff user, I should be able to see non-ccx courses on dashboard

### DIFF
--- a/common/djangoapps/student/views.py
+++ b/common/djangoapps/student/views.py
@@ -588,7 +588,9 @@ def dashboard(request):
     active_affiliates = AffiliateEntity.objects.filter(active=True)
     ccxs = CustomCourseForEdX.objects.all()
     active_ccxs_ids = [unicode(ccx.ccx_course_id) for ccx in ccxs if ccx.affiliate in active_affiliates]
-    course_enrollments = [enrollment for enrollment in course_enrollments if unicode(enrollment.course.id) in active_ccxs_ids]
+    course_enrollments = [enrollment for enrollment in course_enrollments if not hasattr(
+    enrollment.course.id, 'ccx') or unicode(enrollment.course.id) in active_ccxs_ids]
+
 
     # sort the enrollment pairs by the enrollment date
     course_enrollments.sort(key=lambda x: x.created, reverse=True)


### PR DESCRIPTION
Fixed by letting through non-ccx courses in inactive affiliates filtering