### PR TITLE
FIX: Hide deactivated affiliates courses

### DIFF
--- a/lms/djangoapps/branding/views.py
+++ b/lms/djangoapps/branding/views.py
@@ -44,7 +44,6 @@ def get_course_enrollments(user):
 
 
 @ensure_csrf_cookie
-@cache_if_anonymous()
 def index(request):
     '''
     Redirects to main page -- info page if user authenticated, or marketing if not


### PR DESCRIPTION
- Stop caching homepage in order to display courses according to the state.